### PR TITLE
2023.05.02 and cherry-pick fixes

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,16 +1,17 @@
 pkgbase = ros2-humble
 	pkgdesc = A set of software libraries and tools for building robot applications
-	pkgver = 2023.03.08
+	pkgver = 2023.05.02
 	pkgrel = 1
 	url = https://docs.ros.org/en/humble/
 	install = ros2-humble.install
 	arch = any
 	license = Apache
+	makedepends = git
 	depends = ros2-arch-deps
-	depends = python-pyqt5-sip4
+	depends = qt6-base
 	depends = assimp
 	depends = gmock
-	source = ros2::git+https://github.com/ros2/ros2#tag=release-humble-20230308
+	source = ros2::git+https://github.com/ros2/ros2#tag=release-humble-20230502
 	sha256sums = SKIP
 
 pkgname = ros2-humble


### PR DESCRIPTION
Successfully built in clean chroot. This commit does:
1. Update to 2023.05.02
2. Add git as makedepend so it can be built in clean chroot
3. Remove python-pyqt5-sip since it's already in ros2-arch-deps package
4. Add qt6-base dependency to prevent something like
````
 undefined reference to `QtPrivate::QMetaTypeInterfaceWrapper<void*>::metaType@Qt_6'
````
5. Cherry pick some fix from https://github.com/m2-farzan/ros2-galactic-PKGBUILD/pull/39

This PR need more run test since my compilation is not done when I submit this PR. I have ancient computer.