### PR TITLE
Update flags for build()

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -28,9 +28,7 @@ makedepends=('git')
 source=(
     "ros2::git+https://github.com/ros2/ros2#tag=release-humble-${pkgver//.}"
 )
-sha256sums=(
-    'SKIP'
-)
+sha256sums=('SKIP')
 install=ros2-humble.install
 
 prepare() {
@@ -73,8 +71,8 @@ build() {
     ## For people with the old version of makepkg.conf
     unset CPPFLAGS
     ## For people with the new version of makepkg.conf
-    CFLAGS=$(sed "s/-Wp,-D_FORTIFY_SOURCE=2\s//g" <(echo $CFLAGS))
-    CXXFLAGS=$(sed "s/-Wp,-D_FORTIFY_SOURCE=2\s//g" <(echo $CXXFLAGS))
+    CFLAGS=$(sed "s/-Wp,-D_FORTIFY_SOURCE=3\s//g" <(echo $CFLAGS))
+    CXXFLAGS=$(sed "s/-Wp,-D_FORTIFY_SOURCE=3\s//g" <(echo $CXXFLAGS))
 
     # Build
     colcon build --merge-install ${COLCON_EXTRA_ARGS} --cmake-args -Wno-dev


### PR DESCRIPTION
Since the newest version of `pacman 6.1.0-3` the flags `CFLAGS` and `CXXFLAGS` got updated, so in the `build()` function the flags need then to be replaced accordingly for building the package, else I got the same issue as discussed [here](https://github.com/m2-farzan/ros2-galactic-PKGBUILD/issues/1)