### PR TITLE
Fixed build fail because of qt_gui_cpp

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros2-humble
 	pkgdesc = A set of software libraries and tools for building robot applications
 	pkgver = 2024.02.22
-	pkgrel = 3
+	pkgrel = 4
 	url = https://docs.ros.org/en/humble/
 	install = ros2-humble.install
 	arch = any

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,6 +9,7 @@
 # Contributor: Kino <github.com/cybaol>
 # Contributor: Zijian <github.com/zijian-x>
 # Contributor: Jingbei Li <github.com/petronny>
+# Contributor: Levi Tempfli <github.com/levtempfli>
 # Acknowledgment: This work is hugely based on `ros2-arch-deps` AUR
 # package, maintained by T. Borgert.
 
@@ -77,7 +78,7 @@ build() {
     CXXFLAGS=$(sed "s/-Wp,-D_FORTIFY_SOURCE=[23]\s//g" <(echo $CXXFLAGS))
 
     # Build
-    colcon build --merge-install ${COLCON_EXTRA_ARGS} --cmake-args -Wno-dev
+    colcon build --merge-install ${COLCON_EXTRA_ARGS} --cmake-args -Wno-dev --packages-ignore qt_gui_cpp rqt_gui_cpp
 }
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@
 
 pkgname=ros2-humble
 pkgver=2024.02.22
-pkgrel=3
+pkgrel=4
 pkgdesc="A set of software libraries and tools for building robot applications"
 url="https://docs.ros.org/en/humble/"
 arch=('any')


### PR DESCRIPTION
Builds were failing when building `qt_gui_cpp` with the error:
```
CMake Error at src/CMakeLists.txt:10 (message):
  No Python binding generator found.
```

Related: https://github.com/ros-visualization/python_qt_binding/issues/103