### PR TITLE
Fix colcon: error: unrecognized arguments: -Wno-dev

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros2-humble
 	pkgdesc = A set of software libraries and tools for building robot applications
 	pkgver = 2024.02.22
-	pkgrel = 5
+	pkgrel = 6
 	url = https://docs.ros.org/en/humble/
 	install = ros2-humble.install
 	arch = any

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@
 
 pkgname=ros2-humble
 pkgver=2024.02.22
-pkgrel=5
+pkgrel=6
 pkgdesc="A set of software libraries and tools for building robot applications"
 url="https://docs.ros.org/en/humble/"
 arch=('any')
@@ -80,7 +80,7 @@ build() {
     CXXFLAGS=$(sed "s/-Wp,-D_FORTIFY_SOURCE=[23]\s//g" <(echo $CXXFLAGS))
 
     # Build
-    colcon build --merge-install ${COLCON_EXTRA_ARGS} --cmake-args -Wno-dev --packages-ignore qt_gui_cpp rqt_gui_cpp
+    colcon build --merge-install ${COLCON_EXTRA_ARGS} --cmake-args " -Wno-dev" --packages-ignore qt_gui_cpp rqt_gui_cpp
 }
 
 package() {


### PR DESCRIPTION
According to colcon --cmake-args documentation:
Arguments matching other options must be prefixed by a space.